### PR TITLE
Fix hardcoded tflite path: use LV2 bundle_path instead of /usr/lib/lv2

### DIFF
--- a/src/fretboard.cpp
+++ b/src/fretboard.cpp
@@ -58,9 +58,11 @@ void FretBoard::setMidiOutput(LV2_Atom_Sequence *output)
     // }
 }
 
-void FretBoard::initialize()
+void FretBoard::initialize(const std::string& bundle_path)
 {
-    m_noteinferencer.initialize();
+    m_noteinferencer.initialize(bundle_path);
+
+
     // if (m_midioutput)
     //     m_midioutput->initializeSequence();
     // omp_set_num_threads(1);

--- a/src/guitarmidi.cpp
+++ b/src/guitarmidi.cpp
@@ -59,6 +59,7 @@ instantiate(const LV2_Descriptor *descriptor,
 	lv2_log_note(&g_logger, "Using butterworth filters");
 #endif
 	FretBoard *fretboard = new FretBoard(map, rate);
+fretboard->initialize(std::string(bundle_path));
 	return (LV2_Handle)fretboard;
 }
 
@@ -105,7 +106,6 @@ activate(LV2_Handle instance)
 {
 	lv2_log_note(&g_logger, "Activating GuitarMidi-LV2 Plugin\n");
 	FretBoard *notecl = (FretBoard *)instance;
-	notecl->initialize();
 }
 
 /** Define a macro for converting a gain in dB to a coefficient. */

--- a/src/include/fretboard.hpp
+++ b/src/include/fretboard.hpp
@@ -102,7 +102,7 @@ public:
      * @brief initialize the filterbank
      * 
      */
-    void initialize();
+    void initialize(const std::string& bundle_path);
 
     /**
      * @brief finalize all filters and release allocated resources

--- a/src/include/modelinferencer.hpp
+++ b/src/include/modelinferencer.hpp
@@ -97,7 +97,7 @@ class ModelInferencer {
     public:
         ModelInferencer();
         ~ModelInferencer();
-        void initialize();
+        void initialize(const std::string& bundle_path);
         void add_audio_input(const float* input, int num_frames);
         bool get_model_output(float* output, int num_frames);
 };

--- a/src/include/noteinferencer.hpp
+++ b/src/include/noteinferencer.hpp
@@ -51,7 +51,7 @@ namespace GuitarMidi{
         public:
         NoteInferencer(LV2_URID_Map *map);
 
-        void initialize();
+        void initialize(const std::string& bundle_path);
         void setMidiOutput(LV2_Atom_Sequence *output);
 
         void setAudioInputBuffer(AudioBuffer2D input);

--- a/src/modelinferencer.cpp
+++ b/src/modelinferencer.cpp
@@ -1,102 +1,103 @@
-#include <modelinferencer.hpp>
-#include <iostream>
-#include <tensorflow/lite/logger.h>
-    // TFlite C++ API reference: https://ai.google.dev/edge/api/tflite/cc?hl=en
-#define TFLITE_MINIMAL_CHECK(x)                                  \
-    if (!(x))                                                    \
-    {                                                            \
-        fprintf(stderr, "Error at %s:%d\n", __FILE__, __LINE__); \
-        exit(1);                                                 \
-    }
-void GuitarMidi::ModelInferencer::inferencing_loop()
-{
-    while (!stop_thread) {
-        // std::unique_lock<std::mutex> lock(buffer_mutex);
-        // buffer_cv.wait(lock, [this] { return stop_thread || audio_input_buffer.has_new_data(); });
-        if (stop_thread) break;
-
-      
-
-    if (audio_input_buffer.has_new_data() && m_interpreter) {
-            float* input_buffer=m_interpreter->typed_input_tensor<float>(0);
-            audio_input_buffer.get_latest_data(input_buffer); // Assuming 1 frame of input
-            TFLITE_MINIMAL_CHECK(m_interpreter->Invoke() == kTfLiteOk);
-
-            TfLiteTensor *output = m_interpreter->output_tensor(0);
-            float* output_data=m_interpreter->typed_output_tensor<float>(0);
-            // print the output dims
-            TfLiteIntArray* output_dims = output->dims;
-    
-                // Add the model output to the model output ring buffer
-                model_output_buffer.add_data(output_data); // Assuming 1 frame of output
-            }
-
-
-    }
-}
-
-void GuitarMidi::ModelInferencer::initialize()
-{
-            // Load model
-        m_model = FlatBufferModel::BuildFromFile("/usr/lib/lv2/guitarmidi.lv2/guitarmidi.tflite");
-        TFLITE_MINIMAL_CHECK(m_model != nullptr);
-        ops::builtin::BuiltinOpResolver resolver;
-        InterpreterBuilder builder(*m_model, resolver);
-
-        builder(&m_interpreter);
-        TfLiteXNNPackDelegateOptions xnnpack_options =
-            TfLiteXNNPackDelegateOptionsDefault();
-        xnnpack_options.num_threads = 4; // Set number of threads as appropriate for your
-                                         // platform and application needs.
-        xnnpack_options.weight_cache_file_path = TfLiteXNNPackDelegateInMemoryFilePath();
-        // xnnpack_options.logging_level = TFLITE_XNNPACK_LOGGING_LEVEL_ERROR;
-
-        if (m_interpreter->ModifyGraphWithDelegate(
-                TfLiteXNNPackDelegateCreate(&xnnpack_options)) != kTfLiteOk)
-        {
-            // Handle error, but usually optional
-            fprintf(stderr, "Warning: Failed to apply XNNPACK delegate.\n");
+    #include <modelinferencer.hpp>
+    #include <iostream>
+    #include <tensorflow/lite/logger.h>
+        // TFlite C++ API reference: https://ai.google.dev/edge/api/tflite/cc?hl=en
+    #define TFLITE_MINIMAL_CHECK(x)                                  \
+        if (!(x))                                                    \
+        {                                                            \
+            fprintf(stderr, "Error at %s:%d\n", __FILE__, __LINE__); \
+            exit(1);                                                 \
         }
-        // Allocate tensor buffers.
-        TFLITE_MINIMAL_CHECK(m_interpreter->AllocateTensors() == kTfLiteOk);
-        printf("=== Pre-invoke Interpreter State ===\n");
-        // tflite::PrintInterpreterState(m_interpreter.get());
-        tflite::LoggerOptions::SetMinimumLogSeverity(tflite::TFLITE_LOG_ERROR);
-}
-
-GuitarMidi::ModelInferencer::ModelInferencer()
-{
-
-    stop_thread = false;
-    m_interpreter=nullptr;
-    inferencing_thread = std::thread(&ModelInferencer::inferencing_loop, this);
-}
-
-GuitarMidi::ModelInferencer::~ModelInferencer()
-{
+    void GuitarMidi::ModelInferencer::inferencing_loop()
     {
-   
-        stop_thread = true;
-    }
-    // buffer_cv.notify_all();
-    if (inferencing_thread.joinable()) {
-        inferencing_thread.join();
-    }
-}
+        while (!stop_thread) {
+            // std::unique_lock<std::mutex> lock(buffer_mutex);
+            // buffer_cv.wait(lock, [this] { return stop_thread || audio_input_buffer.has_new_data(); });
+            if (stop_thread) break;
 
-void GuitarMidi::ModelInferencer::add_audio_input(const float *input, int num_frames)
-{
-    
-    audio_input_buffer.add_data(input);
 
-}
 
-bool GuitarMidi::ModelInferencer::get_model_output(float *output, int num_frames)
-{
-    
-    if (model_output_buffer.has_new_data()) {
-        model_output_buffer.get_latest_data(output);
-        return true;
+        if (audio_input_buffer.has_new_data() && m_interpreter) {
+                float* input_buffer=m_interpreter->typed_input_tensor<float>(0);
+                audio_input_buffer.get_latest_data(input_buffer); // Assuming 1 frame of input
+                TFLITE_MINIMAL_CHECK(m_interpreter->Invoke() == kTfLiteOk);
+
+                TfLiteTensor *output = m_interpreter->output_tensor(0);
+                float* output_data=m_interpreter->typed_output_tensor<float>(0);
+                // print the output dims
+                TfLiteIntArray* output_dims = output->dims;
+
+                    // Add the model output to the model output ring buffer
+                    model_output_buffer.add_data(output_data); // Assuming 1 frame of output
+                }
+
+
+        }
     }
-    return false;
-}
+
+    void GuitarMidi::ModelInferencer::initialize(const std::string& bundle_path)
+    {
+                // Load model
+            std::string tflite_path = bundle_path + "/guitarmidi.tflite";
+    m_model = FlatBufferModel::BuildFromFile(tflite_path.c_str());
+            TFLITE_MINIMAL_CHECK(m_model != nullptr);
+            ops::builtin::BuiltinOpResolver resolver;
+            InterpreterBuilder builder(*m_model, resolver);
+
+            builder(&m_interpreter);
+            TfLiteXNNPackDelegateOptions xnnpack_options =
+                TfLiteXNNPackDelegateOptionsDefault();
+            xnnpack_options.num_threads = 4; // Set number of threads as appropriate for your
+                                            // platform and application needs.
+            xnnpack_options.weight_cache_file_path = TfLiteXNNPackDelegateInMemoryFilePath();
+            // xnnpack_options.logging_level = TFLITE_XNNPACK_LOGGING_LEVEL_ERROR;
+
+            if (m_interpreter->ModifyGraphWithDelegate(
+                    TfLiteXNNPackDelegateCreate(&xnnpack_options)) != kTfLiteOk)
+            {
+                // Handle error, but usually optional
+                fprintf(stderr, "Warning: Failed to apply XNNPACK delegate.\n");
+            }
+            // Allocate tensor buffers.
+            TFLITE_MINIMAL_CHECK(m_interpreter->AllocateTensors() == kTfLiteOk);
+            printf("=== Pre-invoke Interpreter State ===\n");
+            // tflite::PrintInterpreterState(m_interpreter.get());
+            tflite::LoggerOptions::SetMinimumLogSeverity(tflite::TFLITE_LOG_ERROR);
+    }
+
+    GuitarMidi::ModelInferencer::ModelInferencer()
+    {
+
+        stop_thread = false;
+        m_interpreter=nullptr;
+        inferencing_thread = std::thread(&ModelInferencer::inferencing_loop, this);
+    }
+
+    GuitarMidi::ModelInferencer::~ModelInferencer()
+    {
+        {
+
+            stop_thread = true;
+        }
+        // buffer_cv.notify_all();
+        if (inferencing_thread.joinable()) {
+            inferencing_thread.join();
+        }
+    }
+
+    void GuitarMidi::ModelInferencer::add_audio_input(const float *input, int num_frames)
+    {
+
+        audio_input_buffer.add_data(input);
+
+    }
+
+    bool GuitarMidi::ModelInferencer::get_model_output(float *output, int num_frames)
+    {
+
+        if (model_output_buffer.has_new_data()) {
+            model_output_buffer.get_latest_data(output);
+            return true;
+        }
+        return false;
+    }

--- a/src/noteinferencer.cpp
+++ b/src/noteinferencer.cpp
@@ -15,11 +15,11 @@ namespace GuitarMidi
     NoteInferencer::NoteInferencer(LV2_URID_Map *map) : m_frames(0), m_midioutput(map)
     {
     }
-    void NoteInferencer::initialize()
+    void NoteInferencer::initialize(const std::string& bundle_path)
     {
         m_midioutput.initializeSequence();
         m_frames = 0;
-        m_model.initialize();
+        m_model.initialize(bundle_path);
     }
     void NoteInferencer::setMidiOutput(LV2_Atom_Sequence *output)
     {


### PR DESCRIPTION
Fix hardcoded tflite path: use LV2 bundle_path

The plugin was using a hardcoded path /usr/lib/lv2/guitarmidi.lv2/guitarmidi.tflite
to load the TFLite model. This fails on systems that install LV2 plugins to
~/.lv2 (e.g. CachyOS/Arch Linux).

This fix passes the bundle_path from the LV2 instantiate() callback through
the call chain to ModelInferencer::initialize(), where it is used to construct
the correct path dynamically.